### PR TITLE
feat: add ignore spells options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 ignored_by_git/

--- a/HintMeRank.lua
+++ b/HintMeRank.lua
@@ -23,6 +23,11 @@ AddonLoadedEventBus:SetScript('OnEvent', function(self, event, addonName)
             NotificationDelay = 10
             print(string.format("|cffFF0000[HMR] Broken Notification-Delay fixed! Resetted to 10 minutes again.|r"))
         end
+        -- init/fix SpellIgnoreList table
+        if (type(SpellIgnoreList) ~= "table") then
+            SpellIgnoreList = {}
+            print(string.format("|cffFF0000[HMR] Broken Spell-Ignore-List fixed! Resetted to empty list again.|r"))
+        end
     end
 end)
 
@@ -162,6 +167,10 @@ SlashCmdList["HINTMERANK"] = function(paramStr)
             CACHE.maxSkillRanksAtLevel = {}
             print(string.format("|cffFFFF00[HMR] Cache cleared.|r"))
         end
+    -- chat commmand to clear the ignored spells
+    elseif cmd == "clear-ignored" then
+        table.wipe(SpellIgnoreList)
+        print(string.format("|cffFFFF00[HMR] Spell-Ignore-List cleared.|r"))
     else
         if mainFrameInitialized == false then
             createMainWindow()

--- a/funcs.lua
+++ b/funcs.lua
@@ -2,7 +2,11 @@
 -- ================================================================================
 -- TODO describe function, params & return
 -- ================================================================================
-function isSpellOutranked(spellId) 
+function isSpellOutranked(spellId)
+    if SpellIgnoreList[spellId] then
+        return false -- return false when spell is in the ignored table
+    end
+
     local spellname = GetSpellInfo(spellId)
 
     if Spells[spellId] == nil or Spells[spellId]["nextRank"] == nil then
@@ -38,6 +42,30 @@ function findMaxAvailableRank(spellId) -- returns the spellId of the max avail r
     return spellId
 end
 
+-- Adds the spellId to the ignore list so it won't be considered for upranking
+--- @param spellId number
+function ignoreSpellRank(spellId)
+    tinsert(SpellIgnoreList, spellId, true)
+    print(string.format(i18n["spell ignored one rank"], GetSpellInfo(spellId), GetSpellSubtext(spellId)))
+end
+
+-- Adds all ranks starting from the current rank of the spell to the ignore list so none of them will be considered for upranking
+--- @param currentRankSpellId number
+function ignoreAllSpellRanks(currentRankSpellId)
+    local spellId = currentRankSpellId
+    while spellId do
+        tinsert(SpellIgnoreList, spellId, true)
+
+        local spell = Spells[spellId]
+        if spell ~= nil and spell["nextRank"] ~= nil then
+            spellId = Spells[spellId]["nextRank"]["id"]
+        else
+            spellId = nil
+        end
+    end
+    print(string.format(i18n["spell ignored all ranks"], GetSpellInfo(currentRankSpellId), GetSpellSubtext(currentRankSpellId)))
+end
+
 -- ================================================================================
 -- ================================================================================
 -- TODO describe function, params & return
@@ -45,3 +73,14 @@ end
 function isClassSpell(spellId)
     return Spells[spellId] ~= nil
 end
+
+ -- tcount: count table members even if they're not indexed by numbers
+ --- @param tab table
+ --- @return number
+ function tcount(tab)
+   local n = 0
+   for _ in pairs(tab) do
+     n = n + 1
+   end
+   return n
+ end

--- a/i18n/de.lua
+++ b/i18n/de.lua
@@ -9,8 +9,15 @@ if GetLocale() == "deDE" then
             "kann auf",
             "aufgewertet werden.",
             "AUFWERTEN",
-            "LEHRER"
+            "LEHRER",
+            "or"
         },
+        ["ignored one rank"] = "ignored one rank",
+        ["ignored all ranks"] = "ignored all ranks",
+        ["spell ignored one rank"] = "Spell %s %s ignored for one rank upgrade.",
+        ["spell ignored all ranks"] = "Spell %s ignored for all rank upgrades, starting from rank %s.",
+        ["all ignored cleared"] = "All spell ignored cleared.",
+        ["clear ignored"] = "Clear ignored",
         ["uprank all"] = "Alle aufwerten"
     }
 end

--- a/i18n/en.lua
+++ b/i18n/en.lua
@@ -9,8 +9,15 @@ if GetLocale() == "enGB" or GetLocale() == "enUS" then
             "can be upranked to",
             "",
             "UPRANK",
-            "TEACHER"
+            "TEACHER",
+            "or"
         },
+        ["ignored one rank"] = "ignored one rank",
+        ["ignored all ranks"] = "ignored all ranks",
+        ["spell ignored one rank"] = "Spell %s %s ignored for one rank upgrade.",
+        ["spell ignored all ranks"] = "Spell %s ignored for all rank upgrades, starting from rank %s.",
+        ["all ignored cleared"] = "All spell ignored cleared.",
+        ["clear ignored"] = "Clear ignored",
         ["uprank all"] = "Uprank all"
     }
 end

--- a/i18n/es.lua
+++ b/i18n/es.lua
@@ -11,8 +11,15 @@ if GetLocale() == "esES" or GetLocale() == "esMX" then
             "se puede mejorar a",
             "",
             "MEJORAR",
-            "INSTRUCTOR"
+            "INSTRUCTOR",
+            "or"
         },
+        ["ignored one rank"] = "ignored one rank",
+        ["ignored all ranks"] = "ignored all ranks",
+        ["spell ignored one rank"] = "Spell %s %s ignored for one rank upgrade.",
+        ["spell ignored all ranks"] = "Spell %s ignored for all rank upgrades, starting from rank %s.",
+        ["all ignored cleared"] = "All spell ignored cleared.",
+        ["clear ignored"] = "Clear ignored",
         ["uprank all"] = "Mejorar todo"
     }
 end

--- a/i18n/fr.lua
+++ b/i18n/fr.lua
@@ -11,8 +11,15 @@ if GetLocale() == "frFR" then
             "peu être amélioré vers",
             "",
             "AMELIORER",
-            "APPRENDRE"
+            "APPRENDRE",
+            "or"
         },
+        ["ignored one rank"] = "ignored one rank",
+        ["ignored all ranks"] = "ignored all ranks",
+        ["spell ignored one rank"] = "Spell %s %s ignored for one rank upgrade.",
+        ["spell ignored all ranks"] = "Spell %s ignored for all rank upgrades, starting from rank %s.",
+        ["all ignored cleared"] = "All spell ignored cleared.",
+        ["clear ignored"] = "Clear ignored",
         ["uprank all"] = "Améliorer tout"
     }
 end


### PR DESCRIPTION
Added ignore spells feature.
I have tried to move along with your "button as text" concept, dunno if you're gonna like it, let me know 😄 

So, when there's at least one not ignored, downranked spell, user has an option to ignore one, or all ranks of the spell, starting from the current rank:
![WoWScrnShot_120525_192238](https://github.com/user-attachments/assets/068fc18a-0273-49ac-b9bf-63cbc73e474f)

When at least one spell (one rank of the spell) is on ignore list, button "Clear ignored" also shows up:
![WoWScrnShot_120525_192257](https://github.com/user-attachments/assets/06157fd3-2a00-4251-a6ce-8d5c446e5b8c)

When all spells are ignored or upranked, button "Clear ignored", to let user reset his choices.
![WoWScrnShot_120525_192303](https://github.com/user-attachments/assets/5d345f01-9c40-497a-839a-0ea604ebffaa)

There is also chat command to clear the ignored list, it goes `/hmr clear-ignored` or `/hintmerank clear-ignored`.

Let me know what do you think, of course feel free to do whatever you like with the code. Regards!

P.S.
Translations need to be done. I don't know German, French or Spanish so I just added English everywhere. I just didn't want to use a translator because I wouldn't be able to judge whether it was correct.